### PR TITLE
FIX: CreateMessageItem-event.json

### DIFF
--- a/events/CreateMessageItem-event.json
+++ b/events/CreateMessageItem-event.json
@@ -21,6 +21,7 @@
             "Value": "CreateMessageItem"
           }
         }
-     }
+      }
+    }
   ]
 }


### PR DESCRIPTION
Fixing `CreateMessageItem-event.json` adding a missing `}`
Fixes https://github.com/ServerlessOpsIO/serverless-hello-world-py/issues/1